### PR TITLE
Add grouping props support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,24 @@ const StyledBox = styled("div", {
 
 <StyledBox style={{ color: "$colors.red.600" }}>Styled!</StyledBox>;
 ```
+
+### Grouping Props
+
+Several convenience props apply values to multiple CSS properties at once.
+
+| Prop     | Expanded properties               |
+| -------- | --------------------------------- |
+| `marginX` | `marginLeft`, `marginRight`       |
+| `marginY` | `marginTop`, `marginBottom`       |
+| `paddingX` | `paddingLeft`, `paddingRight`     |
+| `paddingY` | `paddingTop`, `paddingBottom`     |
+| `size`     | `width`, `height`                |
+| `minSize`  | `minWidth`, `minHeight`          |
+| `maxSize`  | `maxWidth`, `maxHeight`          |
+
+```tsx
+const Box = styled("div", {
+  size: "$sizes.md",
+  "@media (min-width: 600px)": { maxSize: "100%" },
+});
+```

--- a/src/__snapshots__/sheet.test.ts.snap
+++ b/src/__snapshots__/sheet.test.ts.snap
@@ -110,6 +110,32 @@ exports[`generateSheets > generates custom property reference with kebab-case tr
 ]
 `;
 
+exports[`generateSheets > generates grouped props 1`] = `
+[
+  {
+    "className": "j1kv7",
+    "css": ".j1kv7 { width: var(--j-sizes-md); }",
+  },
+  {
+    "className": "j15ya",
+    "css": ".j15ya { height: var(--j-sizes-md); }",
+  },
+]
+`;
+
+exports[`generateSheets > generates grouped props in media query 1`] = `
+[
+  {
+    "className": "j1i0a",
+    "css": "@media (min-width: 600px){ .j1i0a { max-width: 100%; } }",
+  },
+  {
+    "className": "j19vc",
+    "css": "@media (min-width: 600px){ .j19vc { max-height: 100%; } }",
+  },
+]
+`;
+
 exports[`generateSheets > generates multiple properties 1`] = `
 [
   {

--- a/src/groupings.ts
+++ b/src/groupings.ts
@@ -1,0 +1,11 @@
+export const groupingMap = {
+  marginX: { props: ["marginLeft", "marginRight"], kind: "spaces" },
+  marginY: { props: ["marginTop", "marginBottom"], kind: "spaces" },
+  paddingX: { props: ["paddingLeft", "paddingRight"], kind: "spaces" },
+  paddingY: { props: ["paddingTop", "paddingBottom"], kind: "spaces" },
+  size: { props: ["width", "height"], kind: "sizes" },
+  minSize: { props: ["minWidth", "minHeight"], kind: "sizes" },
+  maxSize: { props: ["maxWidth", "maxHeight"], kind: "sizes" },
+} as const;
+
+export type GroupingProps = keyof typeof groupingMap;

--- a/src/sheet.test.ts
+++ b/src/sheet.test.ts
@@ -178,6 +178,26 @@ describe("generateSheets", () => {
     expect(sheets).toHaveLength(1);
     expect(sheets).toMatchSnapshot();
   });
+
+  test("generates grouped props", () => {
+    const sheets = generateSheets({
+      size: "$sizes.md",
+    });
+
+    expect(sheets).toHaveLength(2);
+    expect(sheets).toMatchSnapshot();
+  });
+
+  test("generates grouped props in media query", () => {
+    const sheets = generateSheets({
+      "@media (min-width: 600px)": {
+        maxSize: "100%",
+      },
+    });
+
+    expect(sheets).toHaveLength(2);
+    expect(sheets).toMatchSnapshot();
+  });
 });
 
 describe("generateThemeSheets", () => {

--- a/src/sheet.ts
+++ b/src/sheet.ts
@@ -1,5 +1,6 @@
 import fnv1a from "@sindresorhus/fnv1a";
 import type { ConfigSchema } from "./config";
+import { groupingMap } from "./groupings";
 import type { StyleProps } from "./style-props";
 import { toKebabCase } from "./utils";
 
@@ -13,6 +14,19 @@ export function generateSheets(props: StyleProps, selector = "", atRule = "") {
 
   for (const [rawKey, rawValue] of Object.entries(props)) {
     if (rawValue != null && rawValue !== "") {
+      if (rawKey in groupingMap) {
+        const map = groupingMap[rawKey as keyof typeof groupingMap];
+        for (const prop of map.props) {
+          const nestedSheets = generateSheets(
+            { [prop]: rawValue } as StyleProps,
+            selector,
+            atRule,
+          );
+          sheets.push(...nestedSheets);
+        }
+        continue;
+      }
+
       if (typeof rawValue === "object") {
         const nestedSheets = rawKey.startsWith("@")
           ? generateSheets(rawValue, selector, rawKey) // At rules (media query)

--- a/src/style-props.ts
+++ b/src/style-props.ts
@@ -1,5 +1,6 @@
 import type * as CSS from "csstype";
 import type { Tokens } from "./config";
+import type { GroupingProps, groupingMap } from "./groupings";
 
 type ColorProps =
   | "color"
@@ -41,7 +42,7 @@ type TokensRef<Kind extends string> =
 type CSSProperties = CSS.Properties<(string & {}) | number>;
 
 export type StyleProps =
-  | {
+  | ({
       [K in keyof CSSProperties]: K extends ColorProps
         ? TokensRef<"colors"> | CSSProperties[K]
         : K extends SpaceProps
@@ -53,7 +54,11 @@ export type StyleProps =
               : K extends RadiusProps
                 ? TokensRef<"radii"> | CSSProperties[K]
                 : CSSProperties[K];
-    }
+    } & {
+      [K in GroupingProps]?:
+        | TokensRef<(typeof groupingMap)[K]["kind"]>
+        | CSSProperties[(typeof groupingMap)[K]["props"][number]];
+    })
   | {
       [K in string]: (string & {}) | StyleProps;
     };


### PR DESCRIPTION
## Summary
- enable grouped style props via new `groupingMap`
- type StyleProps to support grouped props
- expand grouped props in sheet generation
- document `size`, `minSize` and `maxSize` props
- test grouped props including inside media queries

## Testing
- `pnpm run check`
- `pnpm test`